### PR TITLE
Update to lodash 4+.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "angular",
     "lang2js",
     "angularjs",
-	"translate",
-	"i18n",
-	"l10n",
-	"internationalization",
-	"localization"
+    "translate",
+    "i18n",
+    "l10n",
+    "internationalization",
+    "localization"
   ],
   "homepage": "https://github.com/sscovil/gulp-ng-lang2js",
   "bugs": "https://github.com/sscovil/gulp-ng-lang2js/issues",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "gulp-util": "*",
-    "lodash": "^3.3.0",
+    "lodash": "^4.0.0",
     "map-stream": "*"
   },
   "engines": {


### PR DESCRIPTION
Lodash use in gulp-ng-lang2js is relatively minimal.  The upgrade is safe.  This serves to resolve  npmjs.com/advisories/577, npmjs.com/advisories/782, npmjs.com/advisories/1065, and npmjs.com/advisories/1523.